### PR TITLE
change for django 1.6+

### DIFF
--- a/example/manage.py
+++ b/example/manage.py
@@ -1,14 +1,9 @@
 #!/usr/bin/env python
-import sys
-sys.path.insert(0, '..')
-
-from django.core.management import execute_manager
-try:
-    import settings # Assumed to be in the same directory.
-except ImportError:
-    import sys
-    sys.stderr.write("Error: Can't find the file 'settings.py' in the directory containing %r. It appears you've customized things.\nYou'll have to run django-admin.py, passing it your settings module.\n(If the file settings.py does indeed exist, it's causing an ImportError somehow.)\n" % __file__)
-    sys.exit(1)
-
+import os, sys
+import settings
 if __name__ == "__main__":
-    execute_manager(settings)
+    os.environ.setdefault("DJANGO_SETTINGS_MODULE", 'settings')
+
+    from django.core.management import execute_from_command_line
+
+    execute_from_command_line(sys.argv)

--- a/example/settings.py
+++ b/example/settings.py
@@ -98,7 +98,7 @@ import django # A quick and very dirty test to see if it's 1.3 yet...
 if django.VERSION[0] < 1 or django.VERSION[1] < 3:
     MIDDLEWARE_CLASSES.append('cbv.middleware.DeferredRenderingMiddleware')
 
-ROOT_URLCONF = 'example.urls'
+ROOT_URLCONF = 'urls'
 
 TEMPLATE_DIRS = (
     # Put strings here, like "/home/html/django_templates" or "C:/www/django/templates".

--- a/example/urls.py
+++ b/example/urls.py
@@ -1,5 +1,5 @@
 from django.conf.urls import patterns, include, url
-from example.myshop.views import MyOrderConfirmView
+from myshop.views import MyOrderConfirmView
 
 from shop import urls as shop_urls
 from django.contrib import admin


### PR DESCRIPTION
i changed manage.py so as for those who are using django 1.5+ can run the example project. 
because unless you get error that you cant import name execute_manager.  because execute_manage was deprecated after django 1.4 (https://docs.djangoproject.com/en/1.4/internals/deprecation/#id3) and  execute_from_command_line() took place.